### PR TITLE
`load_tabby()` for loading tabby records as structured data

### DIFF
--- a/datalad_tabby/io/__init__.py
+++ b/datalad_tabby/io/__init__.py
@@ -1,6 +1,11 @@
+from __future__ import annotations
+
 import csv
 from pathlib import Path
-from typing import List
+from typing import (
+    Dict,
+    List,
+)
 
 from openpyxl import (
     Workbook,
@@ -9,7 +14,136 @@ from openpyxl import (
 from openpyxl.worksheet.worksheet import Worksheet
 
 
-__all__ = ['xlsx2tabby', 'tabby2xlsx']
+__all__ = ['xlsx2tabby', 'tabby2xlsx', 'load_tabby']
+
+
+def load_tabby(
+    src: Path,
+    *,
+    single: bool = True,
+    jsonld: bool = True,
+) -> Dict | List:
+    """Load a tabby (TSV) record as structured (JSON(-LD)) data
+
+    The record is identified by the table/sheet file path ``src``. This need
+    not be the root 'dataset' sheet, but can be any component of the full
+    record.
+
+    The ``single`` flag determines whether the record is interpreted as a
+    single entity (i.e., JSON object), or many entities (i.e., JSON array of
+    (homogeneous) objects).  Depending on the ``single`` flag, either a
+    ``dict`` or a ``list`` is returned.
+
+    Other tabby tables/sheets are loaded when ``@tabby-single|many-`` import
+    statements are discovered. The corresponding data structures are replace
+    the import statement at its location.
+
+    .. todo::
+
+      With the ``jsonld`` flag, a declared or default JSON-LD context or frame
+      is inserted and/or applied.
+
+    """
+    return (_load_tabby_single if single else _load_tabby_many)(
+        src=src,
+        jsonld=jsonld,
+    )
+
+
+def _load_tabby_single(
+    *,
+    src: Path,
+    jsonld: bool,
+) -> Dict:
+    obj = {}
+    with src.open(newline='') as tsvfile:
+        reader = csv.reader(tsvfile, delimiter='\t')
+        # row_id is useful for error reporting
+        for row_id, row in enumerate(reader):
+            # row is a list of field, with only as many items
+            # as this particular row has columns
+            if not len(row) or not row[0] or row[0].startswith('#'):
+                # skip empty rows, rows with no key, or rows with
+                # a comment key
+                continue
+            key = row[0]
+            val = row[1:]
+            # cut `val` short and remove trailing empty items
+            val = val[:_get_index_after_last_nonempty(val)]
+            if not val:
+                # skip properties with no value(s)
+                continue
+            # look for @tabby-... imports in values, and act on them
+            val = [
+                _resolve_value(v, src, jsonld=jsonld)
+                for v in val
+            ]
+            # we do not amend values for keys!
+            # another row for an already existing key overwrites
+            # we support "sequence" values via multi-column values
+            # supporting two ways just adds unecessary complexity
+            obj[key] = val if len(val) > 1 else val[0]
+
+    # TODO with jsonld==True, looks for a context, look for a frame
+    return obj
+
+
+def _resolve_value(v: str, src_sheet_fpath: Path, jsonld: bool):
+    src = src_sheet_fpath
+    return (
+        _load_tabby_single(
+            src=_get_corresponding_sheet_fpath(src, v[14:]),
+            jsonld=jsonld)
+        if v.startswith('@tabby-single-')
+        else
+        _load_tabby_many(
+            src=_get_corresponding_sheet_fpath(src, v[12:]),
+            jsonld=jsonld)
+        if v.startswith('@tabby-many-')
+        else v
+    )
+
+
+def _get_corresponding_sheet_fpath(fpath: Path, sheet_name: str):
+    return fpath.parent / \
+        f'{_get_tabby_prefix_from_sheet_fpath(fpath)}_{sheet_name}.tsv'
+
+
+def _get_tabby_prefix_from_sheet_fpath(fpath: Path) -> str:
+    stem = fpath.stem
+    # stem up to, but not including, the last '_'
+    return stem[:(-1) * stem[::1].index('_') - 2]
+
+
+def _get_index_after_last_nonempty(val: List) -> int:
+    for i, v in enumerate(val[::-1]):
+        if v:
+            return len(val) - i
+    return 0
+
+
+def _load_tabby_many(
+    *,
+    src: Path,
+    jsonld: bool,
+) -> List[Dict]:
+    array = list()
+    with src.open(newline='') as tsvfile:
+        reader = csv.DictReader(tsvfile, delimiter='\t')
+        # row_id is useful for error reporting
+        for row_id, row in enumerate(reader):
+            if row[reader.fieldnames[0]].startswith('#'):
+                # skip comment row
+                continue
+            # skip empty fields
+            row = {
+                k:
+                _resolve_value(v, src, jsonld=jsonld)
+                for k, v in row.items()
+                if v
+            }
+            array.append(row)
+    return array
 
 
 def xlsx2tabby(src: Path, dest: Path) -> List[Path]:

--- a/datalad_tabby/io/__init__.py
+++ b/datalad_tabby/io/__init__.py
@@ -104,7 +104,7 @@ def _resolve_value(v: str, src_sheet_fpath: Path, jsonld: bool):
     )
 
 
-def _get_corresponding_sheet_fpath(fpath: Path, sheet_name: str):
+def _get_corresponding_sheet_fpath(fpath: Path, sheet_name: str) -> Path:
     return fpath.parent / \
         f'{_get_tabby_prefix_from_sheet_fpath(fpath)}_{sheet_name}.tsv'
 
@@ -137,7 +137,9 @@ def _load_tabby_many(
         for row_id, row in enumerate(reader):
             # row is a list of field, with only as many items
             # as this particular row has columns
-            if not len(row) or not row[0] or row[0].startswith('#'):
+            if not len(row) \
+                    or row[0].startswith('#') \
+                    or all(v is None for v in row):
                 # skip empty rows, rows with no key, or rows with
                 # a comment key
                 continue

--- a/datalad_tabby/io/__init__.py
+++ b/datalad_tabby/io/__init__.py
@@ -35,7 +35,7 @@ def load_tabby(
     ``dict`` or a ``list`` is returned.
 
     Other tabby tables/sheets are loaded when ``@tabby-single|many-`` import
-    statements are discovered. The corresponding data structures are replace
+    statements are discovered. The corresponding data structures then replace
     the import statement at its location.
 
     .. todo::

--- a/datalad_tabby/io/tests/__init__.py
+++ b/datalad_tabby/io/tests/__init__.py
@@ -1,0 +1,23 @@
+
+from pathlib import Path
+import pytest
+
+from datalad_next.tests.utils import md5sum
+
+import datalad_tabby.tests as dttests
+
+
+@pytest.fixture(autouse=False, scope="session")
+def tabby_tsv_record():
+    srcdir = Path(dttests.__file__).parent / 'data' / 'demorecord'
+    sheets = list(srcdir.glob('tabbydemo_*.tsv'))
+
+    root_sheet = srcdir / 'tabbydemo_dataset.tsv'
+    assert root_sheet in sheets
+    assert root_sheet.exists()
+
+    yield dict(
+        root_sheet=root_sheet,
+        sheets=sheets,
+        md5={s.name: md5sum(s) for s in sheets},
+    )

--- a/datalad_tabby/io/tests/test_load.py
+++ b/datalad_tabby/io/tests/test_load.py
@@ -30,19 +30,31 @@ def tabby_record_basic_components(tmp_path_factory):
     many = rdir / 'rec_manytab.tsv'
     many.write_text(
         # first row MUST define header
-        "k1\tk2\tk3\n"
+        # there are two k2 columns, indicating that two values can be given
+        "k1\tk2\tk2\tk3\n"
         "#headercomment\t\t\n"
-        "a\tb\tc\n"
-        "#ignoreme\t\t\n"
+        "a\tb\t\tc\n"
+        "#ignoreme\t\t\t\n"
         # there is no such thing as a field-comment
-        "1\t2\t#3\n"
+        "1\t2\t\t#3\n"
         # empty fields are skipped
-        "f\t\tl\n"
+        "f\t\t\tl\n"
+        # t0o few fields are OK, remaining keys are skipped
+        "one\ttwo\n"
+        # too many fields values are appended to last key
+        # this is useful for representing a single
+        # "and any number of X..." properties
+        "a\tb\t\tc\t1\t2\t3\n"
+        # merge values in columns with identical names
+        "a\t1\t2\tb\n"
     )
     many_t = [
         {'k1': 'a', 'k2': 'b', 'k3': 'c'},
         {'k1': '1', 'k2': '2', 'k3': '#3'},
         {'k1': 'f', 'k3': 'l'},
+        {'k1': 'one', 'k2': 'two'},
+        {'k1': 'a', 'k2': 'b', 'k3': ['c', '1', '2', '3']},
+        {'k1': 'a', 'k2': ['1', '2'], 'k3': 'b'},
     ]
     root = rdir / 'rec_root.tsv'
     root.write_text(
@@ -62,8 +74,9 @@ def tabby_record_basic_components(tmp_path_factory):
 def test_load_tabby(tabby_record_basic_components):
     trbc = tabby_record_basic_components
     for t in ('single', 'many', 'root'):
-        assert load_tabby(
+        loaded = load_tabby(
             trbc['input'][t],
             single=t != 'many',
             jsonld=False,
-        ) == trbc['target'][t]
+        )
+        assert loaded == trbc['target'][t]

--- a/datalad_tabby/io/tests/test_load.py
+++ b/datalad_tabby/io/tests/test_load.py
@@ -1,0 +1,69 @@
+import pytest
+
+from .. import load_tabby
+
+from . import tabby_tsv_record
+
+
+@pytest.fixture(scope="session")
+def tabby_record_basic_components(tmp_path_factory):
+    rdir = tmp_path_factory.mktemp("rec")
+    single = rdir / 'rec_singletab.tsv'
+    single.write_text(
+        # empty line up top
+        "\n"
+        "\t\t\t\n"
+        "one\t1\n"
+        "two\t2\t\n"
+        "#ignoreme\t\n"
+        "twomany\t1\tb\t3\n"
+        "sparse\ts\t\tf\n"
+        # keys with no value are skipped
+        "undefined\t\t\t\n"
+    )
+    single_t = {
+        'one': '1',
+        'two': '2',
+        'twomany': ['1', 'b', '3'],
+        'sparse': ['s', '', 'f'],
+    }
+    many = rdir / 'rec_manytab.tsv'
+    many.write_text(
+        # first row MUST define header
+        "k1\tk2\tk3\n"
+        "#headercomment\t\t\n"
+        "a\tb\tc\n"
+        "#ignoreme\t\t\n"
+        # there is no such thing as a field-comment
+        "1\t2\t#3\n"
+        # empty fields are skipped
+        "f\t\tl\n"
+    )
+    many_t = [
+        {'k1': 'a', 'k2': 'b', 'k3': 'c'},
+        {'k1': '1', 'k2': '2', 'k3': '#3'},
+        {'k1': 'f', 'k3': 'l'},
+    ]
+    root = rdir / 'rec_root.tsv'
+    root.write_text(
+        "single\t@tabby-single-singletab\n"
+        "many\t@tabby-many-manytab\n"
+    )
+    root_t = {
+        'single': single_t,
+        'many': many_t,
+    }
+    yield dict(
+        input=dict(root=root, single=single, many=many),
+        target=dict(root=root_t, single=single_t, many=many_t),
+    )
+
+
+def test_load_tabby(tabby_record_basic_components):
+    trbc = tabby_record_basic_components
+    for t in ('single', 'many', 'root'):
+        assert load_tabby(
+            trbc['input'][t],
+            single=t != 'many',
+            jsonld=False,
+        ) == trbc['target'][t]

--- a/datalad_tabby/io/tests/test_load.py
+++ b/datalad_tabby/io/tests/test_load.py
@@ -38,7 +38,7 @@ def tabby_record_basic_components(tmp_path_factory):
         # there is no such thing as a field-comment
         "1\t2\t\t#3\n"
         # empty fields are skipped
-        "f\t\t\tl\n"
+        "\t\t\tl\n"
         # t0o few fields are OK, remaining keys are skipped
         "one\ttwo\n"
         # too many fields values are appended to last key
@@ -51,7 +51,7 @@ def tabby_record_basic_components(tmp_path_factory):
     many_t = [
         {'k1': 'a', 'k2': 'b', 'k3': 'c'},
         {'k1': '1', 'k2': '2', 'k3': '#3'},
-        {'k1': 'f', 'k3': 'l'},
+        {'k3': 'l'},
         {'k1': 'one', 'k2': 'two'},
         {'k1': 'a', 'k2': 'b', 'k3': ['c', '1', '2', '3']},
         {'k1': 'a', 'k2': ['1', '2'], 'k3': 'b'},

--- a/datalad_tabby/io/tests/test_tsv2xlsx.py
+++ b/datalad_tabby/io/tests/test_tsv2xlsx.py
@@ -1,30 +1,15 @@
 from pathlib import Path
+
 import pytest
 
 from datalad_next.tests.utils import md5sum
-
-import datalad_tabby.tests as dttests
 
 from .. import (
     xlsx2tabby,
     tabby2xlsx,
 )
 
-
-@pytest.fixture(autouse=False, scope="session")
-def tabby_tsv_record():
-    srcdir = Path(dttests.__file__).parent / 'data' / 'demorecord'
-    sheets = list(srcdir.glob('tabbydemo_*.tsv'))
-
-    root_sheet = srcdir / 'tabbydemo_dataset.tsv'
-    assert root_sheet in sheets
-    assert root_sheet.exists()
-
-    yield dict(
-        root_sheet=root_sheet,
-        sheets=sheets,
-        md5={s.name: md5sum(s) for s in sheets},
-    )
+from . import tabby_tsv_record
 
 
 def test_tsv2xslx_roundtrip(tmp_path, tabby_tsv_record):
@@ -39,3 +24,8 @@ def test_tsv2xslx_roundtrip(tmp_path, tabby_tsv_record):
     # roundtripping via XLSX gives bit identicial outcome compared to
     # TSV starting point
     assert tabby_tsv_record['md5'] == {s.name: md5sum(s) for s in tsvs}
+
+
+def test_raiseon_missing_datasetsheet(tmp_path):
+    with pytest.raises(ValueError):
+        tabby2xlsx(Path('absurd'), tmp_path)


### PR DESCRIPTION
This implements the basic concept described in
https://github.com/psychoinformatics-de/datalad-tabby/issues/15, albeit limit to generating structure (JSON) data, no linked data yet.

TODO

- [x] support/test multi-value properties in `many` tables


Brings back the total project coverage to 100%

- Closes #17