### PR TITLE
Use `@tabby-many-<table-name>` to include vertical tables

### DIFF
--- a/datalad_tabby/tests/data/demorecord/tabbydemo_dataset.tsv
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_dataset.tsv
@@ -16,7 +16,7 @@ sample[organism-part]	whole body
 ""
 # please see all other sheets too
 # all further rows can be ignored, and only detail the relation ship of other data sheets with the dataset metadata record	
-author	@tabby-authors
+author	@tabby-many-authors
 funding	@tabby-many-funding
-has-part	@tabby-files
-publication	@tabby-publications
+has-part	@tabby-many-files
+publication	@tabby-many-publications


### PR DESCRIPTION
This commit changes the demo`_dataset.tsv` table to use `@tabby-many-<table-name>` to include the vertical tables `authors`, `files`, and `publications`.