### PR TITLE
Adds option to return only a single loaded table

### DIFF
--- a/datalad_tabby/io/__init__.py
+++ b/datalad_tabby/io/__init__.py
@@ -41,10 +41,9 @@ def load_tabby(
 
     Other tabby tables/sheets are loaded when ``@tabby-single|many-`` import
     statements are discovered. The corresponding data structures then replace
-    the import statement at its location. Recursive loading of other tables
-    can be deactivated by setting the ``mode`` parameter to ``nonrecursive``,
-    which will result in only the record available at the ``src`` path being
-    loaded.
+    the import statement at its location. Setting the ``recursive`` flag to ``False``
+    disables table import, which will result in only the record available at the
+    ``src`` path being loaded.
 
     .. todo::
 

--- a/datalad_tabby/io/tests/test_load.py
+++ b/datalad_tabby/io/tests/test_load.py
@@ -80,3 +80,23 @@ def test_load_tabby(tabby_record_basic_components):
             jsonld=False,
         )
         assert loaded == trbc['target'][t]
+
+def test_load_tabby_nonrecursive(tabby_record_basic_components):
+    trbc = tabby_record_basic_components
+    loaded_no_r = load_tabby(
+        trbc['input']['root'],
+        single=True,
+        jsonld=False,
+        recursive=False,
+    )
+    assert loaded_no_r == {
+        'many': '@tabby-many-manytab',
+        'single': '@tabby-single-singletab'
+    }
+    loaded_r = load_tabby(
+        trbc['input']['root'],
+        single=True,
+        jsonld=False,
+        recursive=True,
+    )
+    assert loaded_r == trbc['target']['root']

--- a/datalad_tabby/load.py
+++ b/datalad_tabby/load.py
@@ -40,7 +40,7 @@ class Load(dc.ValidatedInterface):
             doc="""Path of the root tabby record component"""),
         mode=dc.Parameter(
             args=("--mode",),
-            doc="""The mode with wich to load a tabby record.
+            doc="""The mode with which to load a tabby record.
             Should be one of 'recursive' (default), 'nonrecursive'.""",
         ),
     )

--- a/datalad_tabby/load.py
+++ b/datalad_tabby/load.py
@@ -6,7 +6,10 @@ import json
 import logging
 
 import datalad_next.commands as dc
-from datalad_next.constraints import EnsurePath
+from datalad_next.constraints import (
+    EnsureChoice,
+    EnsurePath,
+)
 from datalad_next.uis import ui_switcher as ui
 
 from datalad_tabby.io import load_tabby
@@ -19,6 +22,7 @@ class _ParamValidator(dc.EnsureCommandParameterization):
         super().__init__(
             param_constraints=dict(
                 path=EnsurePath(lexists=True),
+                mode=EnsureChoice('recursive', 'nonrecursive')
             ),
         )
 
@@ -34,12 +38,18 @@ class Load(dc.ValidatedInterface):
         path=dc.Parameter(
             args=("path",),
             doc="""Path of the root tabby record component"""),
+        mode=dc.Parameter(
+            args=("--mode",),
+            doc="""The mode with wich to load a tabby record.
+            Should be one of 'recursive' (default), 'nonrecursive'.""",
+        ),
     )
 
     @staticmethod
     @dc.eval_results
     def __call__(
         path,
+        mode: str = 'recursive',
     ):
         rec = load_tabby(
             path,
@@ -47,6 +57,7 @@ class Load(dc.ValidatedInterface):
             single=True,
             # TODO expose as parameter
             jsonld=True,
+            recursive= mode == 'recursive'
         )
 
         yield dc.get_status_dict(

--- a/datalad_tabby/tests/test_load.py
+++ b/datalad_tabby/tests/test_load.py
@@ -1,13 +1,22 @@
 import json
+import pytest
 
 from datalad.api import tabby_load
 
-
 from datalad_tabby.io import load_tabby
 # TODO move to conftest.py
+from datalad_next.constraints.exceptions import CommandParametrizationError
 from datalad_next.tests.fixtures import datalad_noninteractive_ui
 from datalad_tabby.io.tests import tabby_tsv_record
 
+
+def test_arguments(tabby_tsv_record):
+    with pytest.raises(CommandParametrizationError):
+        tabby_load()
+    
+    with pytest.raises(CommandParametrizationError):
+        tabby_load(tabby_tsv_record['root_sheet'], mode='bs')
+            
 
 def test_load(tabby_tsv_record, datalad_noninteractive_ui):
     res = tabby_load(tabby_tsv_record['root_sheet'])
@@ -22,4 +31,17 @@ def test_load(tabby_tsv_record, datalad_noninteractive_ui):
     rec = uil[0][1]
     assert json.loads(
         ''.join(rec)) == load_tabby(tabby_tsv_record['root_sheet'])
+    
+def test_load_nonrecursive(tabby_tsv_record, datalad_noninteractive_ui):
+    res = tabby_load(
+        tabby_tsv_record['root_sheet'],
+        mode='nonrecursive'
+    )
+    res = res[0]
+    uil = datalad_noninteractive_ui.log
+    rec = uil[0][1]
+    assert json.loads(
+        ''.join(rec)) == load_tabby(
+        tabby_tsv_record['root_sheet'],
+        recursive=False)
 


### PR DESCRIPTION
This option can disable the current default recursion happening via tabby import statements, and only return the table specified by die `src` parameter

Changes include:
- adding the `recursive` argument to python functions which defaults to True
- addding the `mode` argument to the cli, which could be one of `recursive` or `nonrecursive`
- updating python and cli tests

To address https://github.com/psychoinformatics-de/datalad-tabby/issues/52
