### PR TITLE
`@id` for entities

### DIFF
--- a/datalad_tabby/tests/data/demorecord/tabbydemo_authors.override.json
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_authors.override.json
@@ -1,0 +1,3 @@
+{
+  "@id": "https://orcid.org/{orcid[0]}"
+}

--- a/datalad_tabby/tests/data/demorecord/tabbydemo_authors.tsv
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_authors.tsv
@@ -2,3 +2,4 @@ name	email	orcid	affiliation	affiliation
 Allison Horst	a@example.com	0000-0002-6047-5564	UC Santa Barbara: Santa Barbara, CA, US
 Alison Hill	b@example.com	0000-0002-8082-1890	RStudio: Boston, MA, US
 Kristen Gorman	c@example.com	0000-0002-0258-9264	University of Alaska Fairbanks: Fairbanks, AK, US
+Dr. Doe	anon@example.com		Secret Agency

--- a/datalad_tabby/tests/data/demorecord/tabbydemo_funding.override.json
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_funding.override.json
@@ -1,3 +1,4 @@
 {
+  "@id": "{funder[0]}/{identifier[0]}",
   "@type": "schema:Grant"
 }

--- a/datalad_tabby/tests/data/demorecord/tabbydemo_publications.override.json
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_publications.override.json
@@ -1,0 +1,3 @@
+{
+  "@id": "https://dx.doi.org/{doi[0]}"
+}


### PR DESCRIPTION
Proper `@id` declarations for metadata objects are key re subsequent cross-linking and general usability. This PR is working towards that.

```json
...
  "author": [
    {
      "@id": "https://orcid.org/0000-0002-6047-5564",
      "orcid": "0000-0002-6047-5564",
      "email": "a@example.com",
      "name": "Allison Horst"
    },
    ...
  ],
  "funding": [
    {
      "@id": "DFG/431549029-INF",
      "@type": "schema:Grant",
      "funder": "DFG",
      "identifier": "431549029-INF"
    },
    ...
  ],
  "name": "Palmer Penguins",
  "publication": {
    "@id": "https://dx.doi.org/10.1371/journal.pone.0090081",
    "@type": "ScholarlyArticle",
    "doi": "10.1371/journal.pone.0090081",
    "date": "2014",
    "citation": "Gorman KB, Williams TD, Fraser WR (2014) Ecological Sexual Dimorphism and Environmental Variability within a Community of Antarctic Penguins (Genus Pygoscelis). PLoS ONE 9(3): e90081."
  }
...
```