### PR TITLE
Declare array of authors to be an ordered list

### DIFF
--- a/datalad_tabby/tests/data/demorecord/tabbydemo_authors.override.json
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_authors.override.json
@@ -1,3 +1,4 @@
 {
-  "@id": "https://orcid.org/{orcid[0]}"
+  "@id": "https://orcid.org/{orcid[0]}",
+  "@type": "schema:Person"
 }

--- a/datalad_tabby/tests/data/demorecord/tabbydemo_dataset.ctx.jsonld
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_dataset.ctx.jsonld
@@ -1,5 +1,8 @@
 {
-  "author": "schema:author",
+  "author": {
+    "@id": "schema:author",
+    "@container":"@list"
+  },
   "funding": "schema:funding",
   "name": "schema:name",
   "publication": "schema:publication"


### PR DESCRIPTION
Looks like this after compaction:

```json
  ...
  "author": {
    "@list": [
      {
        "@id": "https://orcid.org/0000-0002-6047-5564",
        "@type": "schema:Person",
        "orcid": "0000-0002-6047-5564",
        "email": "a@example.com",
        "name": "Allison Horst"
      },
   ...
```

Ping https://github.com/psychoinformatics-de/datalad-tabby/issues/57