### PR TITLE
Support 'single-record-per-directory' format

### DIFF
--- a/datalad_tabby/conftest.py
+++ b/datalad_tabby/conftest.py
@@ -5,6 +5,8 @@ from datalad_next.tests.fixtures import datalad_noninteractive_ui
 from datalad_tabby.tests.fixtures import (
     # provides the tabby "demorecord" that is shipped with the sources
     tabby_tsv_record,
+    # same again, but in a single-record-per-dir layout
+    tabby_tsv_singledir_record,
     # elementary tabby record comprising the key TSV buildiung blocks
     tabby_record_basic_components,
     # no-LD elementary record with overrides

--- a/datalad_tabby/io/load_utils.py
+++ b/datalad_tabby/io/load_utils.py
@@ -62,13 +62,19 @@ def _build_overrides(src: Path, obj: Dict):
 
 
 def _get_corresponding_sheet_fpath(fpath: Path, sheet_name: str) -> Path:
-    return fpath.parent / \
-        f'{_get_tabby_prefix_from_sheet_fpath(fpath)}_{sheet_name}.tsv'
+    prefix = _get_tabby_prefix_from_sheet_fpath(fpath)
+    if prefix:
+        return fpath.parent / f'{prefix}_{sheet_name}.tsv'
+    else:
+        return fpath.parent / f'{sheet_name}.tsv'
 
 
 def _get_record_context_fpath(fpath: Path) -> Path:
     prefix = _get_tabby_prefix_from_sheet_fpath(fpath)
-    return fpath.parent / f'{prefix}.ctx.jsonld'
+    if prefix:
+        return fpath.parent / f'{prefix}.ctx.jsonld'
+    else:
+        return fpath.parent / f'ctx.jsonld'
 
 
 def _get_corresponding_context_fpath(fpath: Path) -> Path:
@@ -85,8 +91,11 @@ def _get_corresponding_override_fpath(fpath: Path) -> Path:
 
 def _get_tabby_prefix_from_sheet_fpath(fpath: Path) -> str:
     stem = fpath.stem
-    # stem up to, but not including, the last '_'
-    return stem[:(-1) * stem[::-1].index('_') - 1]
+    if '_' not in stem:
+        return ''
+    else:
+        # stem up to, but not including, the last '_'
+        return stem[:(-1) * stem[::-1].index('_') - 1]
 
 
 def _get_index_after_last_nonempty(val: List) -> int:

--- a/datalad_tabby/io/tests/test_load.py
+++ b/datalad_tabby/io/tests/test_load.py
@@ -57,3 +57,9 @@ def test_load_almost_tabby_import(tmp_path):
 
     rec = load_tabby(src)
     assert rec['dummy'] == '@tabby-murks'
+
+
+def test_load_singldir_format(tabby_tsv_record, tabby_tsv_singledir_record):
+    rec = load_tabby(tabby_tsv_record['root_sheet'])
+    srec = load_tabby(tabby_tsv_singledir_record['root_sheet'])
+    assert rec == srec


### PR DESCRIPTION
In preparation for
https://github.com/psychoinformatics-de/datalad-tabby/issues/79 and despite the conclusion in
https://github.com/psychoinformatics-de/datalad-tabby/issues/50 this change adds support for a simplified set of files that form a tabby record.

The only thing that is simplified is that the common prefix is removed from all filename. The demo record is not also included in this format.

This layout is what we would like put into a ZIP file container.

The prefix continues to exist (this was the main concern in #50), but is now the name of the parent directory.

In https://github.com/psychoinformatics-de/datalad-tabby/issues/55 this simplifies the setup for the self-description of a dataset. All files could go into `.datalad/tabby/self/` and have short names like:

- `dataset.tsv`
- `dataset.override.json`
- ...

There is no particular additional markup necessary to distinguish single-item-dir format from the prefixed-layout. The absence of an underscore char, is evidence enough.

Closes #50 (for real)