### PR TITLE
Minimalistic `tabby` metadata extractor with datalad-metalad

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -165,12 +165,11 @@ install:
   # Install git-annex on windows, otherwise INSTALL_SYSPKGS can be used
   # deploy git-annex, if desired
   - cmd: IF DEFINED INSTALL_GITANNEX datalad-installer --sudo ok %INSTALL_GITANNEX%
-  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer --sudo ok ${INSTALL_GITANNEX}"
   # in case of a snapshot installation, use the following approach to adjust
   # the PATH as necessary
-  #- sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
+  - sh: "[ -n \"${INSTALL_GITANNEX}\" ] && datalad-installer -E ${HOME}/dlinstaller_env.sh --sudo ok ${INSTALL_GITANNEX}"
   # add location of datalad installer results to PATH
-  #- sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
+  - sh: "[ -f ${HOME}/dlinstaller_env.sh ] && . ${HOME}/dlinstaller_env.sh || true"
 
 
 #before_build:

--- a/datalad_tabby/conftest.py
+++ b/datalad_tabby/conftest.py
@@ -1,6 +1,6 @@
 from datalad.conftest import setup_package
 
-from datalad_next.tests.fixtures import datalad_noninteractive_ui
+pytest_plugins = "datalad_next.tests.fixtures"
 
 from datalad_tabby.tests.fixtures import (
     # provides the tabby "demorecord" that is shipped with the sources

--- a/datalad_tabby/extractor.py
+++ b/datalad_tabby/extractor.py
@@ -1,0 +1,76 @@
+"""datalad-metalad metadata extractor"""
+
+from typing import Dict
+import uuid
+
+from datalad_metalad.extractors.base import (
+    DatasetMetadataExtractor,
+    DataOutputCategory,
+    ExtractorResult,
+)
+from datalad_next.commands import get_status_dict
+from datalad_next.datasets import Dataset
+from datalad_next.exceptions import CapturedException
+
+from datalad_tabby.io import load_tabby
+
+
+def load_dataset_self_description(ds: Dataset) -> Dict:
+    root_sheet = ds.pathobj / '.datalad' / 'tabby' / 'self' / 'dataset.tsv'
+    if not root_sheet.exists():
+        raise LookupError
+
+    dsmeta = load_tabby(
+        root_sheet,
+        single=True,
+        jsonld=True,
+        recursive=True,
+    )
+    return dsmeta
+
+
+class TabbyExtractor(DatasetMetadataExtractor):
+    def get_id(self) -> uuid.UUID:
+        """Return a fixed UUID that identifies this extractor"""
+        return uuid.uuid5(
+            uuid.NAMESPACE_URL,
+            'https://datalad.org/metalad/extractors/tabby-dataset',
+        )
+
+    def get_version(self) -> str:
+        """Returns an arbitrary version label"""
+        return "0.0.1"
+
+    def get_data_output_category(self) -> DataOutputCategory:
+        """This extractor yields its result immediately and directly"""
+        return DataOutputCategory.IMMEDIATE
+
+    def get_required_content(self) -> bool:
+        """TODO needs to `get()` `.datalad/tabby`"""
+        return True
+
+    def extract(self, _=None) -> ExtractorResult:
+        dsmeta = {}
+        extraction_success = False
+        try:
+            dsmeta = load_dataset_self_description(self.dataset)
+            extraction_success = True
+            res = get_status_dict(status='ok')
+        except LookupError:
+            res = get_status_dict(status='impossible')
+            # TODO https://github.com/datalad/datalad-metalad/issues/385
+        except Exception as e:
+            res = get_status_dict(
+                status='error',
+                exception=CapturedException(e),
+            )
+
+        res['type'] = 'dataset'
+
+        return ExtractorResult(
+            extractor_version=self.get_version(),
+            extraction_parameter=self.parameter or {},
+            extraction_success=extraction_success,
+            datalad_result_dict=res,
+            immediate_data=dsmeta,
+        )

--- a/datalad_tabby/extractor.py
+++ b/datalad_tabby/extractor.py
@@ -1,6 +1,9 @@
 """datalad-metalad metadata extractor"""
 
-from typing import Dict
+from typing import (
+    Any,
+    Dict,
+)
 import uuid
 
 from datalad_metalad.extractors.base import (
@@ -27,6 +30,17 @@ def load_dataset_self_description(ds: Dataset) -> Dict:
         recursive=True,
     )
     return dsmeta
+
+
+# key terms, we use ful URLs to avoid having to fiddle with context
+# prefixes and possibly conflicting definitions
+isVersionOf = 'https://purl.org/dc/terms/isVersionOf'
+hasVersion = 'https://purl.org/dc/terms/hasVersion'
+
+# id resolver endpoints
+# TODO under discussion https://github.com/datalad/datalad-registry/issues/217
+dx_dataset = 'https://dx.datalad.org/dataset/'
+dx_dataset_version = 'https://dx.datalad.org/dataset-version/'
 
 
 class TabbyExtractor(DatasetMetadataExtractor):
@@ -65,6 +79,8 @@ class TabbyExtractor(DatasetMetadataExtractor):
                 exception=CapturedException(e),
             )
 
+        self._amend_tabby(dsmeta)
+
         res['type'] = 'dataset'
 
         return ExtractorResult(
@@ -74,3 +90,62 @@ class TabbyExtractor(DatasetMetadataExtractor):
             datalad_result_dict=res,
             immediate_data=dsmeta,
         )
+
+    def _amend_tabby(self, meta):
+        # we override the top-level '@id' to force the report into the
+        # corset of the datalad ID concept.
+        # this report is a "version-level description" in the
+        # W3C HCLS recommendation
+        # TODO log if exists
+        # TODO if there is no concept ID
+        meta['@id'] = self.ds_version_id
+
+        # establish an isVersionOf linkage to the dataset concept-ID
+        # via which any version of this dataset can be located in a
+        # knowledge graph
+        summary_lvl = self._get_ds_summary_lvl_desc()
+        if summary_lvl:
+            _add2meta(meta, isVersionOf, summary_lvl)
+
+        # It is tricky to mess with @type here
+        # - without JSON-LD processing it is hard to figure out if any
+        #   @type is already declared
+        # - without knowing that there is no type, we cannot "enforce"
+        #   one, because we do not know which class the report belongs
+        #   too
+        # However, we specially process the dataset's self-description
+        # here, we can document this behavior
+        # TODO ^^^
+        if '@type' not in meta:
+            meta['@type'] = 'https://schema.org/Dataset'
+
+    # TODO migrate to metalad base class
+    @property
+    def ds_concept_id(self):
+        dsid = self.dataset.id
+        # ATM metalad does not run on repos without a datalad dataset ID
+        assert dsid
+        # https://github.com/datalad/datalad-registry/issues/217
+        return f'{dx_dataset}{self.dataset.id}'
+
+    # TODO migrate to metalad base class
+    @property
+    def ds_version_id(self):
+        # https://github.com/datalad/datalad-registry/issues/217
+        return f'{dx_dataset_version}{self.ref_commit}'
+
+    def _get_ds_summary_lvl_desc(self):
+        return {
+            '@id': self.ds_concept_id,
+            hasVersion: self.ds_version_id,
+        }
+
+
+def _add2meta(meta: Dict, key: str, value: Any) -> None:
+    vals = meta.get(key, [])
+    if not isinstance(vals, list):
+        vals = [vals]
+    vals.append(value)
+    if len(vals) == 1:
+        vals = vals[0]
+    meta[key] = vals

--- a/datalad_tabby/tests/test_extractor.py
+++ b/datalad_tabby/tests/test_extractor.py
@@ -1,0 +1,45 @@
+from datalad.api import meta_extract
+
+from ..extractor import TabbyExtractor
+
+
+def test_extractor_version():
+    ex = TabbyExtractor('someds', 'refcommit')
+    assert str(ex.get_id()) == '325fb444-ae7b-54b3-9fdd-621ab1e5005c'
+
+
+def test_extractor_nometa(existing_dataset):
+    res = meta_extract(
+        'tabby', dataset=existing_dataset,
+        on_failure='ignore', return_type='item-or-list',
+        result_renderer='disabled',
+    )
+    assert res['status'] == 'impossible'
+
+
+def test_extractor_minimal(existing_dataset):
+    ds = existing_dataset
+    mfpath = ds.pathobj / '.datalad' / 'tabby' / 'self' / 'dataset.tsv'
+    mfpath.parent.mkdir(parents=True)
+    mfpath.write_text('title\tmy dataset\n')
+    res = meta_extract(
+        'tabby', dataset=ds, return_type='item-or-list',
+        result_renderer='disabled',
+    )
+    assert res['status'] == 'ok'
+    meta = res['metadata_record']['extracted_metadata']
+    assert meta == {'title': 'my dataset'}
+
+
+def test_extractor_invalidmeta(existing_dataset):
+    ds = existing_dataset
+    mfpath = ds.pathobj / '.datalad' / 'tabby' / 'self' / 'dataset.tsv'
+    mfpath.parent.mkdir(parents=True)
+    mfpath.write_text('title\t@tabby-single-missing\n')
+    res = meta_extract(
+        'tabby', dataset=ds,
+        on_failure='ignore', return_type='item-or-list',
+        result_renderer='disabled',
+    )
+    assert res['status'] == 'error'
+    assert 'no such file' in res['error_message'].lower()

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ python_requires = >= 3.7
 install_requires =
     datalad >= 0.18.0
     datalad-next @ git+https://github.com/datalad/datalad-next.git@main
+    datalad-metalad
     openpyxl
     pyld
 packages = find_namespace:
@@ -43,6 +44,8 @@ datalad.extensions =
     # the entrypoint can point to any symbol of any name, as long it is
     # valid datalad interface specification (see demo in this extensions)
     tabby = datalad_tabby:command_suite
+datalad.metadata.extractors =
+    tabby = datalad_tabby.extractor:TabbyExtractor
 
 [versioneer]
 # See the docstring in versioneer.py for instructions. Note that you must


### PR DESCRIPTION
TODO essential features:

- [x] needs to set `@id` for the root document on the dataset
- [x] needs to set `@type` for the root document on the dataset
- [x] needs to yield other records from `/dscollection`


Ping: https://github.com/psychoinformatics-de/datalad-tabby/issues/2

- Closes https://github.com/psychoinformatics-de/datalad-tabby/issues/55
- Closes https://github.com/psychoinformatics-de/datalad-tabby/issues/2