### PR TITLE
Support sheet convention declaration

### DIFF
--- a/datalad_tabby/io/conventions/tby-sd1/authors.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/authors.ctx.jsonld
@@ -1,0 +1,9 @@
+{
+  "bibo": "https://purl.org/ontology/bibo/",
+  "obo": "https://purl.obolibrary.org/",
+  "schema": "https://schema.org",
+  "affiliation": "schema:affiliation",
+  "email": "schema:email",
+  "name": "schema:name",
+  "orcid": "obo:IAO_0000708"
+}

--- a/datalad_tabby/io/conventions/tby-sd1/authors.override.json
+++ b/datalad_tabby/io/conventions/tby-sd1/authors.override.json
@@ -1,0 +1,4 @@
+{
+  "@id": "https://orcid.org/{orcid[0]}",
+  "@type": "schema:Person"
+}

--- a/datalad_tabby/io/conventions/tby-sd1/dataset.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/dataset.ctx.jsonld
@@ -1,0 +1,18 @@
+{
+  "bibo": "https://purl.org/ontology/bibo/",
+  "obo": "https://purl.obolibrary.org/",
+  "schema": "https://schema.org",
+  "author": "schema:author",
+  "citation": "schema:citation",
+  "description": "schema:description",
+  "doi": "bibo:doi",
+  "funding": "schema:funding",
+  "homepage": "schema:mainEntityOfPage",
+  "identifier": "schema:identifier",
+  "keyword": "schema:keywords",
+  "last-updated": "schema:dateModified",
+  "license": "schema:license",
+  "name": "schema:name",
+  "title": "schema:title",
+  "version": "schema:version"
+}

--- a/datalad_tabby/io/conventions/tby-sd1/dataset.json
+++ b/datalad_tabby/io/conventions/tby-sd1/dataset.json
@@ -1,0 +1,4 @@
+{
+  "author": "@tabby-many-authors@tby-sd1",
+  "funding": "@tabby-optional-many-funding@tby-sd1"
+}

--- a/datalad_tabby/io/conventions/tby-sd1/funding.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/funding.ctx.jsonld
@@ -1,0 +1,6 @@
+{
+  "schema": "https://schema.org",
+  "funder": "schema:funder",
+  "grant_id": "schema:identifier",
+  "title": "schema:title"
+}

--- a/datalad_tabby/io/conventions/tby-sd1/funding.override.json
+++ b/datalad_tabby/io/conventions/tby-sd1/funding.override.json
@@ -1,0 +1,3 @@
+{
+  "@type": "schema:Grant"
+}

--- a/datalad_tabby/io/tests/test_conventions.py
+++ b/datalad_tabby/io/tests/test_conventions.py
@@ -1,0 +1,28 @@
+from .. import load_tabby
+
+
+def test_load_tabby_scids(tmp_path):
+    # minimalistic record in singledir format
+    ds = tmp_path / 'dataset@tby-sd1.tsv'
+    ds.write_text("name\tmyds\n")
+    authors = tmp_path / 'authors@tby-sd1.tsv'
+    authors.write_text(
+        "name\temail\torcid\taffiliation\n"
+        "Josiah Carberry\tjc@example.com\t0000-0002-1825-0097\tBrown University\n"
+    )
+    funding = tmp_path / 'funding@tby-sd1.tsv'
+    funding.write_text(
+        "funder\tgrant_id\ttitle\n"
+        "DFG\tSFB000-INF\tShort but ambitious project\n"
+    )
+    loaded = load_tabby(ds, single=True, jsonld=True)
+    # basic props
+    assert loaded['name'] == 'myds'
+    # context for everything
+    for doc in (loaded, loaded['author'][0], loaded['funding'][0]):
+        assert '@context' in doc
+    # author @id
+    assert all('@id' in a for a in loaded['author'])
+    # and @types
+    assert all('@type' in a for a in loaded['author'])
+    assert all('@type' in f for f in loaded['funding'])

--- a/docs/source/conventions/index.rst
+++ b/docs/source/conventions/index.rst
@@ -1,0 +1,49 @@
+.. _chap_conventions:
+
+Conventions for sheet formats and semantics
+===========================================
+
+`tabby` records can conform to a particular (set of) conventions that
+cover individual composition of a record, the semantic definition
+of its components, and/or the employed vocabularies.
+
+Employed conventions are declared on a per-sheet basis, by including their
+label directly in the sheet name (see :ref:`sec_convention_declaration`).
+
+Technically, a convention can be thought of as a (default) provider for any
+sheet component (context, overrides, JSON data, or even a sheet itself). This
+means that if a record does not contain any such sheet component the convention
+specification is checked for a matching component, which is then used, if it
+exists.
+
+Conventions enable rather minimal tabby records. They can adopt semantics and
+override logic from a convention, and thereby avoid duplication across
+individual records. Only on load a complete record is built and reported.
+Individual sheets in a record need not use a single convention, but may
+mix-and-match from any available convention.
+
+
+.. toctree::
+   :caption: Built-in conventions
+   :maxdepth: 1
+
+   tby-sd1.rst
+
+
+Adding new/Updating built-in conventions
+----------------------------------------
+
+Labels of all built-in conventions:
+
+- start with the ``tby-`` prefix.  This is an arbitrary prefix that aims to
+  minimize name conflicts with user-provided conventions.
+- include a short name for the convention.
+- include a version number. This version number is incremented whenever
+  backward-incompatible changes to a convention specification are made.
+
+
+Convention specifications are put into a
+``datalad_tabby/io/conventions/<label>/`` directory in the package source tree.
+Because the version is included in the directory name, it is ensures that there
+are no naming conflicts when versions are incremented, and previous
+specifications can remain available indefinitely.

--- a/docs/source/conventions/tby-sd1.rst
+++ b/docs/source/conventions/tby-sd1.rst
@@ -1,0 +1,62 @@
+Scientific Dataset (v1, ``tby-sd1``)
+====================================
+
+This convention defines a fairly minimalistic description of a scientific dataset.
+With few exceptions the convention is built on the https://schema.org vocabulary.
+
+
+Sheet ``authors``
+-----------------
+
+Context
+~~~~~~~
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/authors.ctx.jsonld
+   :language: json
+
+Overrides
+~~~~~~~~~
+
+Any entity in the sheet is declared to be of type https://schema.org/Person, using
+a given ORCID as a globally unique IRI.
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/authors.override.json
+   :language: json
+
+
+Sheet ``dataset``
+-----------------
+
+Context
+~~~~~~~
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/dataset.ctx.jsonld
+   :language: json
+
+Default (JSON) data
+~~~~~~~~~~~~~~~~~~~
+
+A dataset must declare authors in a dedicated ``authors`` sheet. A dataset may
+declare associated funding in a dedicated ``funding`` sheet. Both sheets use the
+``tby-sd1`` convention.
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/dataset.json
+   :language: json
+
+
+Sheet ``funding``
+-----------------
+
+Context
+~~~~~~~
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/funding.ctx.jsonld
+   :language: json
+
+Overrides
+~~~~~~~~~
+
+Any entity in the sheet is declared to be of type https://schema.org/Grant.
+
+.. literalinclude:: ../../../datalad_tabby/io/conventions/tby-sd1/funding.override.json
+   :language: json

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,6 +26,7 @@ or sources.
    specification.rst
    usage-examples.rst
    best-practices.rst
+   conventions/index.rst
 
 
 Command line reference

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,7 @@ Acknowledgements
 
 This DataLad extension was developed with support from the Deutsche
 Forschungsgemeinschaft (DFG, German Research Foundation) under grant SFB 1451
-([431549029](https://gepris.dfg.de/gepris/projekt/431549029), INF project).
+(`431549029 <https://gepris.dfg.de/gepris/projekt/431549029>`__, INF project).
 
 
 Indices and tables

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -62,6 +62,21 @@ where
   - ``override.json`` for an `override` specification
 
 
+.. _sec_convention_declaration:
+
+Sheet convention declaration
+----------------------------
+
+Sheet names support a dedicated syntax for declaring that a sheet conforms to a
+particular set of conventions (see :ref:`chap_conventions`). The convention
+label is appended to the sheet name as a suffix, delimited by the ``@``
+character. For example, declaring that the ``dataset`` sheet implements
+``mystandard`` conventions, use ``dataset@mystandard`` as the full sheet name.
+
+Note that for all practical purposes the conventions suffix is a part part of
+the whole sheet name and has to be included anywhere a sheet name is used.
+
+
 Sheet types
 ===========
 


### PR DESCRIPTION
This extends the implementation by recognizing an optional sheet name suffix (`@` delimiter) to indicate that the sheet adopts a particular convention. For example, instead of `dataset.tsv`, a file name can now be `dataset@prj462.tsv`, where `prj462` is an arbitrary label for a particular convention.

The convention label is a regular part of the sheet name, hence its syntax rules apply.

Individual sheets in a record need not use a single convention, but may mix-and-match from any available convention.

If a convention label is declared for a sheet, the convention specification will serve as a fallback (default-provider) for any sheet component (context, overrides, JSON data, or even a sheet itself).  This means that if a record does not contain any such sheet component the convention specification is checked for a matching component, which is then used, if it exists.

This feature enables rather minimal tabby records. They can adopt semantics and override logic from a (set of) convention(s), by simply declaring one in the sheet name(s).

A demo is provided in an included test. A new convention `tby-sd1` is added to the sources, hence provided as a first "standard" convention that is shipped with the package.

`tby-` is an arbitrary prefix that is adopted for this an all future conventions that are included in the package (to minimize name conflicts with user-provided conventions).

`sd` is short for "scientific dataset". It is radically abbreviated to keep the convention label short (good for display when sheets are edited manually).

`1` is a version label for the convention. It needs to be incremented when backward incompatible changes to the convention are made.

In the source tree conventions are stored at
`datalad_tabby/io/conventions/<label>/`. Underneath this directory the convention components are stored like tabby records in "singledir" layout.

This storage convention (where the version is included in the directory name) ensure that there are no naming conflicts when versions are incremented, and previous specifications can remain available indefinitely.

User can provide additional lookup paths for conventions (see `load_tabby(..., convention_paths=[])`. User provided locations are always considered first. If a conventions is defined in multiple locations, the first matching location is used.

At this point the specification of additional convention locations is not integrated into the DataLad `tabby_load()` command. A future update will integrated with the DataLad configuration mechanism.

Demo:

`dataset@tby-sd1.tsv`

```
name	myds
```

`authors@tby-sd1.tsv`

```
name	email	orcid	affiliation
Josiah Carberry	jc@example.com	0000-0002-1825-0097 Brown University
```

`funding@tby-sd1.tsv`

```
funder	grant_id    title
DFG SFB000-INF	Short but ambitious project
```

yields the following JSON-LD record on load:

```json

{
  "author": [
    {
      "name": "Josiah Carberry",
      "email": "jc@example.com",
      "orcid": "0000-0002-1825-0097",
      "affiliation": "Brown University",
      "@id": "https://orcid.org/0000-0002-1825-0097",
      "@type": "schema:Person",
      "@context": {
        "bibo": "https://purl.org/ontology/bibo/",
        "obo": "https://purl.obolibrary.org/",
        "schema": "https://schema.org",
        "affiliation": "schema:affiliation",
        "email": "schema:email",
        "name": "schema:name",
        "orcid": "obo:IAO_0000708"
      }
    }
  ],
  "funding": [
    {
      "funder": "DFG",
      "grant_id": "SFB000-INF",
      "title": "Short but ambitious project",
      "@type": "schema:Grant",
      "@context": {
        "schema": "https://schema.org",
        "funder": "schema:funder",
        "grant_id": "schema:identifier",
        "title": "schema:title"
      }
    }
  ],
  "name": "myds",
  "@context": {
    "bibo": "https://purl.org/ontology/bibo/",
    "obo": "https://purl.obolibrary.org/",
    "schema": "https://schema.org",
    "author": "schema:author",
    "citation": "schema:citation",
    "description": "schema:description",
    "doi": "bibo:doi",
    "funding": "schema:funding",
    "homepage": "schema:mainEntityOfPage",
    "identifier": "schema:identifier",
    "keyword": "schema:keywords",
    "last-updated": "schema:dateModified",
    "license": "schema:license",
    "name": "schema:name",
    "title": "schema:title",
    "version": "schema:version"
  }
}
```

which compacts to

```json
{
  "schema:author": {
    "@id": "https://orcid.org/0000-0002-1825-0097",
    "@type": "schema:Person",
    "https://purl.obolibrary.org/IAO_0000708": "0000-0002-1825-0097",
    "schema:affiliation": "Brown University",
    "schema:email": "jc@example.com",
    "schema:name": "Josiah Carberry"
  },
  "schema:funding": {
    "@type": "schema:Grant",
    "schema:funder": "DFG",
    "schema:identifier": "SFB000-INF",
    "schema:title": "Short but ambitious project"
  },
  "schema:name": "myds"
}
```

- Closes #86

TODO

- [x] Link convention docs in the `tabby` format specification