### PR TITLE
Improve `size[bytes]` definition

### DIFF
--- a/datalad_tabby/io/conventions/tby-ds1/authors.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-ds1/authors.ctx.jsonld
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "email": "schema:email",
   "name": "schema:name"
 }

--- a/datalad_tabby/io/conventions/tby-ds1/dataset.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-ds1/dataset.ctx.jsonld
@@ -1,6 +1,6 @@
 {
   "dcterms": "https://purl.org/dc/terms/",
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "author": "schema:author",
   "description": "schema:description",
   "hasPart": "dcterms:hasPart",

--- a/datalad_tabby/io/conventions/tby-ds1/files.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-ds1/files.ctx.jsonld
@@ -1,8 +1,13 @@
 {
   "afo": "http://purl.allotrope.org/ontologies/result#",
+  "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
   "obo": "https://purl.obolibrary.org/obo/",
   "schema": "https://schema.org",
-  "size[bytes]": "schema:contentSize",
+  "xsd": "http://www.w3.org/2001/XMLSchema#",
+  "size[bytes]": {
+    "@id": "nfo:fileSize",
+    "@type": "xsd:integer"
+  },
   "checksum[md5]": "obo:NCIT_C171276",
   "path[POSIX]": {
     "@id": "schema:name",

--- a/datalad_tabby/io/conventions/tby-ds1/files.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-ds1/files.ctx.jsonld
@@ -2,7 +2,7 @@
   "afo": "http://purl.allotrope.org/ontologies/result#",
   "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
   "obo": "https://purl.obolibrary.org/obo/",
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "xsd": "http://www.w3.org/2001/XMLSchema#",
   "size[bytes]": {
     "@id": "nfo:fileSize",

--- a/datalad_tabby/io/conventions/tby-ds1/files.override.json
+++ b/datalad_tabby/io/conventions/tby-ds1/files.override.json
@@ -1,4 +1,3 @@
 {
-  "@id": "{checksum_md5_[0]}",
   "@type": "schema:DigitalDocument"
 }

--- a/datalad_tabby/io/conventions/tby-sd1/authors.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/authors.ctx.jsonld
@@ -1,7 +1,7 @@
 {
   "bibo": "https://purl.org/ontology/bibo/",
   "obo": "https://purl.obolibrary.org/",
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "affiliation": "schema:affiliation",
   "email": "schema:email",
   "name": "schema:name",

--- a/datalad_tabby/io/conventions/tby-sd1/dataset.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/dataset.ctx.jsonld
@@ -1,7 +1,7 @@
 {
   "bibo": "https://purl.org/ontology/bibo/",
   "obo": "https://purl.obolibrary.org/",
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "author": "schema:author",
   "citation": "schema:citation",
   "description": "schema:description",

--- a/datalad_tabby/io/conventions/tby-sd1/funding.ctx.jsonld
+++ b/datalad_tabby/io/conventions/tby-sd1/funding.ctx.jsonld
@@ -1,5 +1,5 @@
 {
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "funder": "schema:funder",
   "grant_id": "schema:identifier",
   "title": "schema:title"

--- a/datalad_tabby/tests/data/demorecord/tabbydemo.ctx.jsonld
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo.ctx.jsonld
@@ -2,5 +2,5 @@
   "bibo": "https://purl.org/ontology/bibo/",
   "dpv": "https://w3id.org/dpv#",
   "obo": "https://purl.obolibrary.org/",
-  "schema": "https://schema.org"
+  "schema": "https://schema.org/"
 }

--- a/datalad_tabby/tests/test_load.py
+++ b/datalad_tabby/tests/test_load.py
@@ -59,7 +59,7 @@ def test_load_compaction(tabby_tsv_record, tmp_path):
     # but compaction takes it out, when we define all relevant IRIs
     # in a global compaction context
     compaction = {
-        "schema": "https://schema.org",
+        "schema": "https://schema.org/",
     }
     compaction_fname = tmp_path / 'compact.jsonld'
     compaction_fname.write_text(json.dumps(compaction))

--- a/docs/source/conventions/tby-ds1_demo/compacted.jsonld
+++ b/docs/source/conventions/tby-ds1_demo/compacted.jsonld
@@ -4,37 +4,35 @@
     "dcterms": "https://purl.org/dc/terms/",
     "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
     "obo": "https://purl.obolibrary.org/obo/",
-    "schema": "https://schema.org",
+    "schema": "https://schema.org/",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
   "@type": "schema:Dataset",
   "dcterms:hasPart": [
     {
-      "@id": "529ff606a38b37a2e5478c1abfeca231",
       "@type": "schema:DigitalDocument",
       "obo:NCIT_C171276": "529ff606a38b37a2e5478c1abfeca231",
-      "nfo:fileSize": {
-        "@type": "xsd:integer",
-        "@value": "1300"
-      },
       "schema:contentUrl": "https://raw.githubusercontent.com/psychoinformatics-de/datalad-tabby/2738d8a12fb138d3fe107c6bee443c13c9f4f6ea/LICENSE",
       "schema:name": {
         "@type": "afo:AFR_0001928",
         "@value": "LICENSE"
+      },
+      "nfo:fileSize": {
+        "@type": "xsd:integer",
+        "@value": "1300"
       }
     },
     {
-      "@id": "ef2979a70a8d95a24cd1402bd68e1c4a",
       "@type": "schema:DigitalDocument",
       "obo:NCIT_C171276": "ef2979a70a8d95a24cd1402bd68e1c4a",
-      "nfo:fileSize": {
-        "@type": "xsd:integer",
-        "@value": "1755"
-      },
       "schema:contentUrl": "https://raw.githubusercontent.com/psychoinformatics-de/datalad-tabby/2738d8a12fb138d3fe107c6bee443c13c9f4f6ea/docs/README.md",
       "schema:name": {
         "@type": "afo:AFR_0001928",
         "@value": "docs/README.md"
+      },
+      "nfo:fileSize": {
+        "@type": "xsd:integer",
+        "@value": "1755"
       }
     }
   ],

--- a/docs/source/conventions/tby-ds1_demo/compacted.jsonld
+++ b/docs/source/conventions/tby-ds1_demo/compacted.jsonld
@@ -2,8 +2,10 @@
   "@context": {
     "afo": "http://purl.allotrope.org/ontologies/result#",
     "dcterms": "https://purl.org/dc/terms/",
+    "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
     "obo": "https://purl.obolibrary.org/obo/",
-    "schema": "https://schema.org"
+    "schema": "https://schema.org",
+    "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
   "@type": "schema:Dataset",
   "dcterms:hasPart": [
@@ -11,7 +13,10 @@
       "@id": "529ff606a38b37a2e5478c1abfeca231",
       "@type": "schema:DigitalDocument",
       "obo:NCIT_C171276": "529ff606a38b37a2e5478c1abfeca231",
-      "schema:contentSize": "1300",
+      "nfo:fileSize": {
+        "@type": "xsd:integer",
+        "@value": "1300"
+      },
       "schema:contentUrl": "https://raw.githubusercontent.com/psychoinformatics-de/datalad-tabby/2738d8a12fb138d3fe107c6bee443c13c9f4f6ea/LICENSE",
       "schema:name": {
         "@type": "afo:AFR_0001928",
@@ -22,7 +27,10 @@
       "@id": "ef2979a70a8d95a24cd1402bd68e1c4a",
       "@type": "schema:DigitalDocument",
       "obo:NCIT_C171276": "ef2979a70a8d95a24cd1402bd68e1c4a",
-      "schema:contentSize": "1755",
+      "nfo:fileSize": {
+        "@type": "xsd:integer",
+        "@value": "1755"
+      },
       "schema:contentUrl": "https://raw.githubusercontent.com/psychoinformatics-de/datalad-tabby/2738d8a12fb138d3fe107c6bee443c13c9f4f6ea/docs/README.md",
       "schema:name": {
         "@type": "afo:AFR_0001928",

--- a/docs/source/conventions/tby-ds1_demo/ds1-compact.jsonld
+++ b/docs/source/conventions/tby-ds1_demo/ds1-compact.jsonld
@@ -3,6 +3,6 @@
   "dcterms": "https://purl.org/dc/terms/",
   "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
   "obo": "https://purl.obolibrary.org/obo/",
-  "schema": "https://schema.org",
+  "schema": "https://schema.org/",
   "xsd": "http://www.w3.org/2001/XMLSchema#"
 }

--- a/docs/source/conventions/tby-ds1_demo/ds1-compact.jsonld
+++ b/docs/source/conventions/tby-ds1_demo/ds1-compact.jsonld
@@ -1,6 +1,8 @@
 {
   "afo": "http://purl.allotrope.org/ontologies/result#",
   "dcterms": "https://purl.org/dc/terms/",
+  "nfo": "https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#",
   "obo": "https://purl.obolibrary.org/obo/",
-  "schema": "https://schema.org"
+  "schema": "https://schema.org",
+  "xsd": "http://www.w3.org/2001/XMLSchema#"
 }


### PR DESCRIPTION
Previously the interpretation was subject to some kind of postprocessing of a potentially existing unit in the string value https://schema.org/contentSize

We switch to https://www.semanticdesktop.org/ontologies/2007/03/22/nfo/#fileSize now, which is much more precise:

    The size of the file in bytes. For compressed files it means the size of
    the packed file, not of the contents.

Moreover, we declare the data type to be integer. This is useful, because when read from a TSV file, the native JSON dtype will be `str`, not `int`.

Closes #103