### PR TITLE
Guess encoding if default does not work

### DIFF
--- a/datalad_tabby/io/load.py
+++ b/datalad_tabby/io/load.py
@@ -98,12 +98,14 @@ class _TabbyLoader:
             )
 
         try:
-            obj.update(self._parse_tsv_single(src))
+            tsv_obj = self._parse_tsv_single(src)
         except UnicodeDecodeError:
             # by default Path.open() uses locale.getencoding()
             # that didn't work, try guessing
             encoding = cs_from_path(src).best().encoding
-            obj.update(self._parse_tsv_single(src, encoding=encoding))
+            tsv_obj = self._parse_tsv_single(src, encoding=encoding)
+
+        obj.update(tsv_obj)
 
         return self._postproc_obj(obj, src=src, trace=trace)
 
@@ -159,18 +161,18 @@ class _TabbyLoader:
         # to do with any possibly loaded JSON data
 
         try:
-            array.extend(
-                self._parse_tsv_many(src, obj_tmpl, trace=trace, fieldnames=None)
+            tsv_array = self._parse_tsv_many(
+                src, obj_tmpl, trace=trace, fieldnames=None
             )
         except UnicodeDecodeError:
             # by default Path.open() uses locale.getencoding()
             # that didn't work, try guessing
             encoding = cs_from_path(src).best().encoding
-            array.extend(
-                self._parse_tsv_many(
-                    src, obj_tmpl, trace=trace, fieldnames=None, encoding=encoding
-                )
+            tsv_array = self._parse_tsv_many(
+                src, obj_tmpl, trace=trace, fieldnames=None, encoding=encoding
             )
+
+        array.extend(tsv_array)
 
         return array
 

--- a/datalad_tabby/io/load.py
+++ b/datalad_tabby/io/load.py
@@ -109,7 +109,7 @@ class _TabbyLoader:
 
         return self._postproc_obj(obj, src=src, trace=trace)
 
-    def _parse_tsv_single(self, src: Path, encoding: bool = None) -> Dict:
+    def _parse_tsv_single(self, src: Path, encoding: str | None = None) -> Dict:
         obj = {}
         with src.open(newline='', encoding=encoding) as tsvfile:
             reader = csv.reader(tsvfile, delimiter='\t')

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     datalad >= 0.18.0
     datalad-next @ git+https://github.com/datalad/datalad-next.git@main
     datalad-metalad
+    charset-normalizer
     openpyxl
     pyld
 packages = find_namespace:


### PR DESCRIPTION
If reading a tsv file with default encoding fails, roll out a cannon ([charset-normalizer](https://charset-normalizer.readthedocs.io)) and try to guess the encoding to use.

By default, `Path.open()` uses `locale.getencoding()` when reading a file (which means that we implicitly use utf-8, at least on linux). This would fail when reading files with non-ascii characters prepared (with not-uncommon settings) on Windows. There is no perfect way to learn the encoding from a plain text file, but existing tools seem to do a good job.

This PR refactors tabby loader (introducing `_parse_tsv_[single, many]`) functions that take an optional encoding argument), which allow us to use guessed encoding (but only after the default fails). Closes #112