### PR TITLE
Ignore empty lines

### DIFF
--- a/datalad_tabby/io/load.py
+++ b/datalad_tabby/io/load.py
@@ -154,9 +154,12 @@ class _TabbyLoader:
             for row_id, row in enumerate(reader):
                 # row is a list of field, with only as many items
                 # as this particular row has columns
-                if not len(row) \
-                        or row[0].startswith('#') \
-                        or all(v is None for v in row):
+                if (
+                    not len(row)
+                    or row[0].startswith("#")
+                    or all(v is None for v in row)
+                    or all(v == "" for v in row)
+                ):
                     # skip empty rows, rows with no key, or rows with
                     # a comment key
                     continue

--- a/datalad_tabby/io/xlsx.py
+++ b/datalad_tabby/io/xlsx.py
@@ -95,4 +95,13 @@ def _sheet2tsv(ws: Worksheet, dest: Path):
             tsvfile,
             delimiter='\t',
         )
-        writer.writerows(ws.iter_rows(values_only=True))
+
+        # find the last nonempty row
+        max_idx = 1
+        for i, row in enumerate(ws.iter_rows(values_only=True)):
+            if any(v is not None for v in row):
+                max_idx = i + 1  # max row is a 1-based index
+
+        # write tsv, truncating empty rows at the end
+        writer.writerows(ws.iter_rows(values_only=True, max_row=max_idx))
+

--- a/datalad_tabby/tests/data/demorecord/tabbydemo_files.tsv
+++ b/datalad_tabby/tests/data/demorecord/tabbydemo_files.tsv
@@ -2,7 +2,3 @@ path[POSIX]	size[bytes]	checksum[md5]	url
 raw/adelie.csv	23755	e7e2be6b203a221949f05e02fcefd853	https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.219.3&entityid=002f3893385f710df69eeebe893144ff
 raw/gentoo.csv	11263	1549566fb97afa879dc9446edcf2015f	https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.220.3&entityid=e03b43c924f226486f2f0ab6709d2381
 raw/chinstrap.csv	18872	e4b0710c69297031d63866ce8b888f25	https://portal.edirepository.org/nis/dataviewer?packageid=knb-lter-pal.221.2&entityid=fe853aa8f7a59aa84cdd3197619ef462
-
-
-
-


### PR DESCRIPTION
This PR resolves #110 
- `datalad_tabby.io.xlsx.xlsx2tabby` will trim blank rows sometimes found at the end of a spreadsheet
- `datalad_tabby.io.load_tabby` will treat empty strings as no value when detecting empty rows to be ignored
- one test tsv tabby file has empty lines at the end removed, to ensure round-tripping with the changes above