### PR TITLE
Add an encoding parameter to `io.load_tabby`

### DIFF
--- a/datalad_tabby/io/load.py
+++ b/datalad_tabby/io/load.py
@@ -28,6 +28,7 @@ def load_tabby(
     jsonld: bool = True,
     recursive: bool = True,
     cpaths: List | None = None,
+    encoding: str | None = None,
 ) -> Dict | List:
     """Load a tabby (TSV) record as structured (JSON(-LD)) data
 
@@ -48,11 +49,16 @@ def load_tabby(
 
     With the ``jsonld`` flag, a declared or default JSON-LD context is
     loaded and inserted into the record.
+
+    Tsv file encoding used when reading can be specified with the
+    ``encoding`` parameter.
+
     """
     ldr = _TabbyLoader(
         jsonld=jsonld,
         recursive=recursive,
         cpaths=cpaths,
+        encoding=encoding,
     )
     return ldr(src=src, single=single)
 
@@ -63,6 +69,7 @@ class _TabbyLoader:
         jsonld: bool = True,
         recursive: bool = True,
         cpaths: List[Path] | None = None,
+        encoding: str | None = None,
     ):
         std_convention_path = Path(__file__).parent / 'conventions'
         if cpaths is None:
@@ -70,6 +77,7 @@ class _TabbyLoader:
         else:
             cpaths.append(std_convention_path)
         self._cpaths = cpaths
+        self._encoding = encoding
         self._jsonld = jsonld
         self._recursive = recursive
 
@@ -95,7 +103,7 @@ class _TabbyLoader:
                 trace=trace,
             )
 
-        with src.open(newline='') as tsvfile:
+        with src.open(newline='', encoding=self._encoding) as tsvfile:
             reader = csv.reader(tsvfile, delimiter='\t')
             # row_id is useful for error reporting
             for row_id, row in enumerate(reader):
@@ -146,7 +154,7 @@ class _TabbyLoader:
         # to do with any possibly loaded JSON data
         fieldnames = None
 
-        with src.open(newline='') as tsvfile:
+        with src.open(newline='', encoding=self._encoding) as tsvfile:
             # we cannot use DictReader -- we need to support identically named
             # columns
             reader = csv.reader(tsvfile, delimiter='\t')

--- a/docs/source/best-practices.rst
+++ b/docs/source/best-practices.rst
@@ -28,7 +28,7 @@ covers the entire document, including content inserted from other tables.
 When individual tables require a different context specification, it can be
 declared in the respective ``<prefix>_<table-name>.ctx.jsonld`` side-car files.
 Such a context is inserted in each metadata object read from the respective
-table. Standard JSON-LD rules for context scoping and propgation apply to the
+table. Standard JSON-LD rules for context scoping and propagation apply to the
 semantics of such a declaration.
 
 A third approach to context specification is a record-global


### PR DESCRIPTION
This PR resolves #112 by adding an optional `encoding` parameter to `io.load_tabby`. The parameter can be used to specify encoding for reading tsv files.

When not specified (`encoding=None`), we keep the default behavior (implicitly using `locale.getencoding()` [^1],[^2]).

With external libraries it might be possible to guess a file encoding that produces a correct result based on the files content, but the success is not guaranteed when there are few non-ascii characters in the entire file (think: list of authors). I made an attempt with #114 but didn't like it in the end. Here, we do not attempt to guess, instead expecting the user to know the encoding they need to use.

This PR also fixes an unrelated documentation typo to satisfy the codespell checks.

[^1]: https://docs.python.org/3/library/pathlib.html#pathlib.Path.open
[^2]: https://docs.python.org/3/library/functions.html#open